### PR TITLE
Revert "switch to stm32 hw crc unit for code checksum"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ SOURCES += src/version.c
 SOURCES += src/syscalls.c
 
 SOURCES += shared/crc8.c
+SOURCES += shared/crc32.c
 SOURCES += shared/common.c
 
 #USB CDC
@@ -59,7 +60,6 @@ INCDIRS += lib/CMSIS/Device/ST/STM32F4xx/Include
 
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_adc.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_dma.c
-SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_crc.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_flash.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_gpio.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_pwr.c

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -22,6 +22,8 @@ SOURCES += bootloader/src/version.c
 SOURCES += bootloader/src/stm32f4xx_it.c
 SOURCES += bootloader/src/system_stm32f4xx.c
 
+SOURCES += shared/crc32.c
+
 # Standard peripheral library
 CPPFLAGS += -DUSE_STDPERIPH_DRIVER
 #CPPFLAGS += -DUSE_FULL_ASSERT
@@ -31,7 +33,6 @@ INCDIRS += lib/CMSIS/Include
 INCDIRS += lib/CMSIS/Device/ST/STM32F4xx/Include
 
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_flash.c
-SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_crc.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_gpio.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_pwr.c
 SOURCES += lib/STM32F4xx_StdPeriph_Driver-V1.6.0/src/stm32f4xx_rcc.c

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -20,6 +20,7 @@
 
 #include "stm32f4xx_conf.h"
 #include "version.h"
+#include "crc32.h"
 
 #define APP_START 0x08010000
 #define APP_END   0x08100000
@@ -27,13 +28,14 @@
 #define VERSION_INFO_OFFSET 0x188
 static volatile const struct version_info *app_info = (void*)(APP_START + VERSION_INFO_OFFSET);
 
-static int app_ok(void)
-{
+int app_ok(){
     if (!APP_RANGE_VALID(APP_START, app_info->image_size)) {
         return 0;
     }
 
-    uint32_t crc = CRC_CalcBlockCRC((uint32_t *) APP_START, app_info->image_size);
+    uint32_t crc = crc32_init();
+    crc = crc32_update(crc, (void*)APP_START, app_info->image_size);
+    crc = crc32_finalize(crc);
 
     if (crc != 0) {
         return 0;
@@ -42,10 +44,9 @@ static int app_ok(void)
     return 1;
 }
 
-int main(void)
-{
+int main(void){
    GPIO_InitTypeDef GPIO_InitDef;
-   RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_CRC, ENABLE);
+   RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
    GPIO_InitDef.GPIO_Pin = GPIO_Pin_13;
    GPIO_InitDef.GPIO_Mode = GPIO_Mode_IN;
    GPIO_InitDef.GPIO_OType = GPIO_OType_PP;

--- a/src/comps/term.comp
+++ b/src/comps/term.comp
@@ -301,7 +301,9 @@ NRT(
       printf_("CMSIS      %i.%i\n",__CM4_CMSIS_VERSION_MAIN,__CM4_CMSIS_VERSION_SUB);
       printf_("StdPeriph  %i.%i.%i\n",__STM32F4XX_STDPERIPH_VERSION_MAIN,__STM32F4XX_STDPERIPH_VERSION_SUB1,__STM32F4XX_STDPERIPH_VERSION_SUB2);
       printf_("CPU ID     %x %x %x\n",U_ID[0], U_ID[1], U_ID[2]);
-      uint32_t crc = CRC_CalcBlockCRC((uint32_t *) 0x08010000, version_info.image_size);
+	  uint32_t crc = crc32_init();
+      crc = crc32_update(crc, (void*)0x08010000, version_info.image_size);
+      crc = crc32_finalize(crc);
       printf_("size: %u crc:%x\n",version_info.image_size,version_info.image_crc);
       if(crc == 0)
          printf_("crc ok!\n");

--- a/src/setup.c
+++ b/src/setup.c
@@ -10,7 +10,7 @@
 
 void setup(){
    //Enable clocks
-   RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB | RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_DMA1 | RCC_AHB1Periph_DMA2 | RCC_AHB1Periph_CRC, ENABLE);
+   RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB | RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_DMA1 | RCC_AHB1Periph_DMA2, ENABLE);
    
 	//messpin
    GPIO_InitStructure.GPIO_Pin   = GPIO_Pin_3 | GPIO_Pin_4 | GPIO_Pin_5 | GPIO_Pin_8 | GPIO_Pin_9;


### PR DESCRIPTION
stm32 crc unit works different. No idea why it worked while testing this.
Python crc code needs work to make this work.

This reverts commit 8feed275939d5050a1e85b63cfd470b5334365cb.