### PR TITLE
move objcpy hv firmware exec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ LDFLAGS  += $(CPU)
 
 # Default target
 #
-all: hv gccversion boot hv build showsize
+all: hv gccversion boot build showsize
 
 build: elf hex bin lss sym
 
@@ -192,8 +192,6 @@ boot_btflash: boot
 hv:
 	$(MAKE) -f stm32f103/Makefile
 
-hv_firmware.o: hv
-	arm-none-eabi-objcopy --rename-section .data=.hv_firmware -I binary obj_hv/hv.bin -B arm -O elf32-littlearm hv_firmware.o
 
 # Display compiler version information
 #

--- a/stm32f103/Makefile
+++ b/stm32f103/Makefile
@@ -135,13 +135,15 @@ LDFLAGS  += $(CPU)
 #
 all:  gccversion build showsize
 
-build: elf hex bin lss sym
+build: elf hex bin lss sym hv_firmware.o
 
 elf: $(TARGET).elf
 hex: $(TARGET).hex
 bin: $(TARGET).bin
 lss: $(TARGET).lss
 sym: $(TARGET).sym
+hv_firmware.o:
+	arm-none-eabi-objcopy --rename-section .data=.hv_firmware -I binary obj_hv/hv.bin -B arm -O elf32-littlearm hv_firmware.o
 
 # Display compiler version information
 #


### PR DESCRIPTION
objcpy was executed every build also if hv firmware ins't changed