### PR TITLE
Try a different way to compute a modulus

### DIFF
--- a/shared/angle.c
+++ b/shared/angle.c
@@ -95,11 +95,5 @@ inline float minus(float a, float b){
 }
 //TODO: blocks hal with large numbers
 inline float mod(float a){
-	while(a < -M_PI){
-		a += 2.0 * M_PI;
-	}
-	while(a > M_PI){
-		a -= 2.0 * M_PI;
-	}
-	return(a);
+	return fmod(a + M_PI, 2.0 * M_PI) - M_PI;
 }

--- a/src/comps/sserial.comp
+++ b/src/comps/sserial.comp
@@ -82,7 +82,7 @@ typedef union{
 #define DATA_TYPE_STREAM 			0x06
 #define DATA_TYPE_BOOLEAN 			0x07
 #define DATA_TYPE_ENCODER  			0x08
-#define DATA_TYPE_FLOAT  			0x09 // New for STMBL
+#define DATA_TYPE_FLOAT  			0x10 // New for STMBL
 #define DATA_TYPE_ENCODER_H     	0x18 
 #define DATA_TYPE_ENCODER_L     	0x28 
 


### PR DESCRIPTION
Also: Choose 0x10 for the FLOAT sserial data type
Signed-off-by: andy pugh <andy@bodgesoc.org>