### PR TITLE
Fixed spelling error in hal_term_print_state function.

### DIFF
--- a/shared/hal.c
+++ b/shared/hal.c
@@ -151,7 +151,7 @@ void hal_term_print_state() {
       printf("HAL state:  NAN_ERROR\n");
       break;
     default:
-      printf("HAL state:  unkonwn error\n");
+      printf("HAL state:  unknown error\n");
   }
 }
 


### PR DESCRIPTION
Was reading through the code and found this simple spelling error. Corrected it.